### PR TITLE
style(logo): added wide logo class to footer align to left side on mo…

### DIFF
--- a/components/footer/footer.js
+++ b/components/footer/footer.js
@@ -54,7 +54,7 @@ class Footer extends React.Component {
 			<footer ref={node => this.footer = node} className="footer">
 				<div className="container-inner">
 					<Link href="/" >
-						<a className="header-logo header-logo-wide">
+						<a className="header-logo">
 							<Logo color="white"/>
 							<h1 className="a11y-sr-only">Hike one</h1>
 						</a>

--- a/components/footer/footer.less
+++ b/components/footer/footer.less
@@ -38,6 +38,13 @@
 	@media @screen-medium {
 		margin-bottom: @spacing-extra-large;
 	}
+
+	@media @screen-large {
+		svg {
+			height: 46px;
+			width: 240px;
+		}
+	}
 }
 
 .footer-left {

--- a/components/menu-bar/menu-bar.less
+++ b/components/menu-bar/menu-bar.less
@@ -73,14 +73,6 @@
 		}
 	}
 }
-.header-logo-wide {
-	@media @screen-large {
-		svg {
-			height: 46px;
-    		width: 240px;
-		}
-	}
-}
 
 .menu-btn {
 	z-index: 3;


### PR DESCRIPTION
- Logo width in header on desktop should be 150px
- Logo width in footer on desktop should be 240px
- On mobile, align left side H with header image below