### PR TITLE
add middleware for domain whitelisting

### DIFF
--- a/lib/www-redirect.js
+++ b/lib/www-redirect.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const fs = require('fs');
+
+const allowedDomains = fs.readFileSync('domains.txt', 'utf8')
+	.trim()
+	.split('\n');
+
+const mainDomain = allowedDomains[0];
+
+module.exports = (req, res, next) => {
+
+	if(process.env.NODE_ENV !== 'production'){
+		return next();
+	}
+
+	const hostname = req.hostname;
+
+	if (!allowedDomains.includes(hostname) || /^www/.test(hostname)) {
+		return res.redirect(301, `https://${mainDomain}${req.url}`);
+	}
+
+	next();
+}

--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 const apiRouter = require('./lib/api-router');
 const dataLoader = require('./lib/data-loader');
 const getSitemap = require('./lib/sitemap');
+const redirection = require('./lib/www-redirect');
+
 const express = require('express');
 const next = require('next');
 const cookieParser = require('cookie-parser');
@@ -22,6 +24,7 @@ server.use(compression());
 server.use(helmet());
 server.use('/sitemap.xml', getSitemap);
 server.use(express.static('./static/root'));
+server.use(redirection);
 server.use(cookieParser());
 server.use('/api/', apiRouter);
 server.use('/guide/', express.static('./build/guide/'));


### PR DESCRIPTION
Add middleware that redirects www to non-www and checks that domain name is an allowed domain. If the runtime environment is not production, this middleware is no-op.