### PR TITLE
Merge 50-50 left/right into one component

### DIFF
--- a/components/50-50/50-50.less
+++ b/components/50-50/50-50.less
@@ -24,11 +24,11 @@
 }
 
 .fifty-fifty .container-inner {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
+	display: flex;
+	align-items: center;
+	flex-direction: column;
 
-    @media @screen-medium {
+	@media @screen-medium {
 		flex-direction: row;
 		margin: 0 auto 0 auto;
 	}
@@ -49,13 +49,13 @@
 
 .fifty-fifty-content,
 .fifty-fifty-image {
-    display: inline-block;
-    width: 100%;
-    vertical-align: top;
+	display: inline-block;
+	width: 100%;
+	vertical-align: top;
 
-    @media @screen-medium {
-        width: 50%;
-    }
+	@media @screen-medium {
+		width: 50%;
+	}
 }
 
 .fifty-fifty-image-large {
@@ -136,18 +136,13 @@
 }
 
 .fifty-fifty-content-left {
+	.container-inner {
+		flex-direction: row-reverse;
+	}
 	.fifty-fifty-title,
 	.fifty-fifty-text {
 		@media @screen-medium {
 			margin-right: 0;
-			float: left;
-		}
-	}
-
-	.fifty-fifty-image {
-		@media @screen-medium {
-			order: 1;
-			float: right;
 		}
 	}
 }
@@ -167,4 +162,3 @@
 	padding-left: 0;
 	padding-right: @spacing-default*7;
 }
-

--- a/components/50-50/50-50.less
+++ b/components/50-50/50-50.less
@@ -137,7 +137,9 @@
 
 .fifty-fifty-content-left {
 	.container-inner {
-		flex-direction: row-reverse;
+		@media @screen-medium {
+			flex-direction: row-reverse;
+		}
 	}
 	.fifty-fifty-title,
 	.fifty-fifty-text {

--- a/pages/case.js
+++ b/pages/case.js
@@ -95,7 +95,7 @@ const Case = ({ Data, fontsLoaded, fullUrl }) => (
 						let itemType = component.itemType
 
 						if (component.itemType === '50_50') {
-							if (component.textPosition === 'text left') {
+							if (component.textLeft) {
 								itemType = '50_50_text_left'
 							} else {
 								itemType = '50_50_text_right'
@@ -143,7 +143,7 @@ const Case = ({ Data, fontsLoaded, fullUrl }) => (
 								return (
 									<FiftyFifty
 										key={index}
-										contentLeft={component.textPosition === 'text left'}
+										contentLeft={component.textLeft}
 										title={component.title}
 										text={component.text}
 										image={component.image.url}

--- a/pages/case.js
+++ b/pages/case.js
@@ -92,7 +92,16 @@ const Case = ({ Data, fontsLoaded, fullUrl }) => (
 					</TextCenter>
 
 					{Data.components.map((component, index) => {
-						const itemType = component.itemType
+						let itemType = component.itemType
+
+						if (component.itemType === '50_50') {
+							if (component.textPosition === 'text left') {
+								itemType = '50_50_text_left'
+							} else {
+								itemType = '50_50_text_right'
+							}
+						}
+
 						// set component count
 						componentCounter = setComponentCounter(componentCounter, itemType, parallaxLayersMap)
 						const count = componentCounter[itemType]
@@ -124,6 +133,19 @@ const Case = ({ Data, fontsLoaded, fullUrl }) => (
 										contentLeft="true"
 										text={component.text}
 										imageLarge="true"
+										image={component.image.url}
+									>
+										{ parallaxLayers }
+									</FiftyFifty>
+								)
+
+							case '50_50':
+								return (
+									<FiftyFifty
+										key={index}
+										contentLeft={component.textPosition === 'text left'}
+										title={component.title}
+										text={component.text}
 										image={component.image.url}
 									>
 										{ parallaxLayers }

--- a/pages/topic.js
+++ b/pages/topic.js
@@ -51,6 +51,17 @@ const Topic = ({ Data, fontsLoaded, fullUrl }) => (
 						case 'body_quote':
 							return <BodyQuote key={index} quote={component.quote} />
 
+						case '50_50':
+							return (
+								<FiftyFifty
+									key={index}
+									contentLeft={component.textPosition === 'text left'}
+									title={component.title}
+									text={component.text}
+									image={component.image.url}
+								/>
+							)
+
 						case '50_50_text_right':
 							return (
 								<FiftyFifty

--- a/pages/topic.js
+++ b/pages/topic.js
@@ -55,7 +55,7 @@ const Topic = ({ Data, fontsLoaded, fullUrl }) => (
 							return (
 								<FiftyFifty
 									key={index}
-									contentLeft={component.textPosition === 'text left'}
+									contentLeft={component.textLeft}
 									title={component.title}
 									text={component.text}
 									image={component.image.url}

--- a/pages/update.js
+++ b/pages/update.js
@@ -52,7 +52,7 @@ const Update = ({ Data, fontsLoaded, fullUrl }) => (
 								<FiftyFifty
 									classes='fifty-fifty-update'
 									key={index}
-									contentLeft={component.textPosition === 'text left'}
+									contentLeft={component.textLeft}
 									title={component.title}
 									text={component.text}
 									image={component.image.url}

--- a/pages/update.js
+++ b/pages/update.js
@@ -47,6 +47,18 @@ const Update = ({ Data, fontsLoaded, fullUrl }) => (
 						case 'body_quote':
 							return <BodyQuote key={index} quote={component.quote} quotee={component.quotee} />
 
+						case '50_50':
+							return (
+								<FiftyFifty
+									classes='fifty-fifty-update'
+									key={index}
+									contentLeft={component.textPosition === 'text left'}
+									title={component.title}
+									text={component.text}
+									image={component.image.url}
+								/>
+							)
+
 						case '50_50_text_right':
 							return (
 								<FiftyFifty


### PR DESCRIPTION
"These 2 components as they are basically all the same. If we want this, I suggest to call this the 50-50 component. 
Of course, we cannot delete the older components as they are used all over the place. This is a migrating process for the editors"

- add the new 50_50 component to case, topic and update pages.
- fix css indentation
- the float: left didn't work with very small titles, so I replaced it with "flex-direction: row-reverse"