### PR TITLE
Feat/align pages

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -68,6 +68,9 @@ import SocialShare from './social-share/social-share.js'
 import StatisticsBlock from './statistics-block/statistics-block.js'
 import TeamImage from './team-image/team-image.js'
 import TeamMember from './team-member/team-member.js'
+import TeamMembersOverview from './team-members-overview/team-members-overview.js'
+import TeamOverview from './team-overview/team-overview.js'
+import TeamSelector from './team-selector/team-selector.js'
 import TextCard from './text-card/text-card.js'
 import TextCenter from './text-center/text-center.js'
 import * as TextCenterShapes from './text-center/text-center-shapes.js'
@@ -81,9 +84,11 @@ import UpdateExtractSmall from './update-extract-small/update-extract-small.js'
 import UpdateExtractLarge from './update-extract-large/update-extract-large.js'
 import UpdateLink from './update-link/update-link.js'
 import UpdateLinks from './update-links/update-links.js'
+import UpdateOverview from './update-overview/update-overview.js'
 import UpdateOverviewSmall from './update-overview-small/update-overview-small.js'
 import UpdatesExtractLarge from './updates-extract-large/updates-extract-large.js'
 import VacancyCard from './vacancy-card/vacancy-card.js'
+import VacancyOverview from './vacancy-overview/vacancy-overview.js'
 import WorkOverview from './work-overview/work-overview.js'
 
 export {
@@ -157,6 +162,9 @@ export {
   StatisticsBlock,
   TeamImage,
   TeamMember,
+  TeamMembersOverview,
+  TeamOverview,
+  TeamSelector,
   TextCard,
   TextCenter,
   TextCenterShapes,
@@ -170,8 +178,10 @@ export {
   UpdateExtractLarge,
   UpdateLink,
   UpdateLinks,
+  UpdateOverview,
   UpdateOverviewSmall,
   UpdatesExtractLarge,
   VacancyCard,
+  VacancyOverview,
   WorkOverview,
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import App, { Container } from 'next/app'
-import { CookieBar } from '../components'
 import cookie from '../components/_helpers/cookie'
+import { CookieBar } from '../components'
 
 export default class MyApp extends App {
   static async getInitialProps({ Component, ctx }) {

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -12,8 +12,12 @@ import {
 } from '../components/'
 
 const Error = ({ data = {}, fontsLoaded = '', wrapperClass = '' }) => (
-  <Layout title="Hike One - Home" fontsLoaded={fontsLoaded} classes={wrapperClass}>
+  <Layout
+    title="Hike One - Home"
+    fontsLoaded={fontsLoaded}
+    classes={wrapperClass}>
     <main className="main js-main">
+
       <MenuBar color="black" />
 
       <article className={`article article-error ${data.image ? 'article-error--has-image' : ''}`}>
@@ -43,10 +47,10 @@ Error.getInitialProps = async ({ res, req, jsonPageRes }) => {
   const statusCode = res
     ? res.statusCode.toString()
     : jsonPageRes ? jsonPageRes.status.toString() : null
-  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
   const baseUrl = req ? `${req.protocol}://${req.get('Host')}` : ''
   const fetchData = await getData(baseUrl, 'error-pages', res)
   const data = fetchData.find(page => page.error === statusCode) // Find correct error page data
+  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
 
   return { data, fontsLoaded }
 }

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -8,7 +8,7 @@ import {
   Layout,
   MenuBar,
   TextCenter,
-  TextCenterShapes
+  TextCenterShapes,
 } from '../components/'
 
 const Error = ({ data = {}, fontsLoaded = '', wrapperClass = '' }) => (

--- a/pages/case.js
+++ b/pages/case.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-
 import getData from '../lib/get-data'
 import cookie from '../components/_helpers/cookie'
 import getDateFormat from '../components/_helpers/getDateFormat'
 import scrollToElement from '../components/_helpers/scrollToElement'
 import setComponentCounter from '../components/_helpers/setParallaxComponentCounter'
-
 import {
   CallToAction,
   CaseExtractSmall,

--- a/pages/case.js
+++ b/pages/case.js
@@ -58,30 +58,32 @@ const parallaxLayersMap = {
 let componentCounter = {}
 const scrollToTargetClass = 'js-scroll-to-target'
 
-const Case = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
+const Case = ({ data = {}, fontsLoaded = '', fullUrl = '' }) => (
   <Layout
-    title={`Hike One - ${Data.title}`}
+    title={`Hike One - ${data.title}`}
     fontsLoaded={fontsLoaded}
-    seo={Data.seo}
+    seo={data.seo}
     url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
+
       <article className="article">
         <PageHeader
           onClickScrollButton={() => scrollToElement(scrollToTargetClass)}
-          video={Data.header.video}
-          title={Data.header.title}
-          subtitle={Data.header.subtitle}
-          image={Data.header.backgroundImage.url}
-          showGradient={Data.header.displayGradient}
+          video={data.header.video}
+          title={data.header.title}
+          subtitle={data.header.subtitle}
+          image={data.header.backgroundImage.url}
+          showGradient={data.header.displayGradient}
         />
 
         <div className={`${scrollToTargetClass} page-scrolling-content`}>
-          <TextCenter title={Data.introTitle} text={Data.introText}>
+          <TextCenter title={data.introTitle} text={data.introText}>
             <TextCenterShapes.variation1Back position="back" />
           </TextCenter>
 
-          {Data.components.map((component, index) => {
+          {data.components.map((component, index) => {
             let itemType = component.itemType
 
             if (component.itemType === '50_50') {
@@ -286,14 +288,14 @@ const Case = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
           })}
 
           <Contact
-            title={Data.contact.title}
-            button={Data.contact.button}
-            link={Data.contact.externalLink}>
+            title={data.contact.title}
+            button={data.contact.button}
+            link={data.contact.externalLink}>
             <ContactShapes.variation1Front position="front" />
           </Contact>
 
           <WorkOverview>
-            {Data.caseExtract.map((item, index) => (
+            {data.caseExtract.map((item, index) => (
               <CaseExtractSmall
                 key={index}
                 title={item.header.title}
@@ -307,7 +309,7 @@ const Case = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
           </WorkOverview>
 
           <UpdateLinks>
-            {Data.updateLinks.map((update, index) => (
+            {data.updateLinks.map((update, index) => (
               <UpdateLink
                 key={index}
                 title={update.title}
@@ -321,7 +323,7 @@ const Case = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
         </div>
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -329,15 +331,15 @@ const Case = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
 
 Case.getInitialProps = async ({ req, res, query, asPath }) => {
   const baseUrl = req ? `${req.protocol}://${req.get('Host')}` : ''
+  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
   const fullUrl = `${baseUrl}${asPath}`
   const data = await getData(baseUrl, `cases/${query.slug}`, res)
-  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
 
-  return { Data: data, fontsLoaded, fullUrl }
+  return { data, fontsLoaded, fullUrl }
 }
 
 Case.propTypes = {
-  Data: PropTypes.object,
+  data: PropTypes.object,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,
 }

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -15,30 +15,35 @@ import {
   VacancyCard,
 } from '../components'
 
-const Contact = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
-  <Layout title="Hike One - Contact" fontsLoaded={fontsLoaded} seo={Data.seo} url={fullUrl}>
+const Contact = ({ data = {}, fontsLoaded = '', fullUrl = '' }) => (
+  <Layout
+    title="Hike One - Contact"
+    fontsLoaded={fontsLoaded}
+    seo={data.seo}
+    url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
 
       <article className="article">
         <PageHeader
           isSmall={true}
-          title={Data.header.title}
-          subtitle={Data.header.subtitle}
-          image={Data.header.backgroundImage.url}
+          title={data.header.title}
+          subtitle={data.header.subtitle}
+          image={data.header.backgroundImage.url}
         />
 
         <div className="page-scrolling-content-small">
-          <ContactForm form={Data.contactForm} />
+          <ContactForm form={data.contactForm} />
 
-          <TextCenter classes="text-center-font-large contact-text-center" text={Data.content}>
+          <TextCenter classes="text-center-font-large contact-text-center" text={data.content}>
             <TextCenterShapes.variation2Back position="back" />
           </TextCenter>
 
-          <VacancyCard data={Data.vacancyCard} />
+          <VacancyCard data={data.vacancyCard} />
 
-          <OfficeOverview header={Data.officesHeader}>
-            {Data.office.map((item, index) => (
+          <OfficeOverview header={data.officesHeader}>
+            {data.office.map((item, index) => (
               <OfficeCard
                 key={index}
                 index={index}
@@ -55,7 +60,7 @@ const Contact = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
         </div>
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -63,15 +68,15 @@ const Contact = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
 
 Contact.getInitialProps = async ({ req, res, asPath }) => {
   const baseUrl = req ? `${req.protocol}://${req.get('Host')}` : ''
+  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
   const fullUrl = `${baseUrl}${asPath}`
   const data = await getData(baseUrl, 'contact', res)
-  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
 
-  return { Data: data, fontsLoaded, fullUrl }
+  return { data, fontsLoaded, fullUrl }
 }
 
 Contact.propTypes = {
-  Data: PropTypes.object,
+  data: PropTypes.object,
   fontsLoaded: PropTypes.bool,
   fullUrl: PropTypes.string,
 }

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,15 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import cookie from '../components/_helpers/cookie'
 import getData from '../lib/get-data'
-
+import cookie from '../components/_helpers/cookie'
 import {
   ContactForm,
   Footer,
   Layout,
   MenuBar,
-  OfficeOverview,
   OfficeCard,
+  OfficeOverview,
   PageHeader,
   TextCenter,
   TextCenterShapes,

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
+import getData from '../lib/get-data'
 import scrollToElement from '../components/_helpers/scrollToElement'
 import cookie from '../components/_helpers/cookie'
-
 import {
   CaseExtract,
   Contact,
@@ -18,7 +18,6 @@ import {
   UpdateExtractSmall,
   UpdateOverviewSmall,
 } from '../components'
-import getData from '../lib/get-data'
 
 const scrollToTargetClass = 'js-scroll-to-target'
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,57 +21,57 @@ import {
 
 const scrollToTargetClass = 'js-scroll-to-target'
 
-const Home = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
-  <Layout title="Hike One - Home" fontsLoaded={fontsLoaded} seo={Data.seo} url={fullUrl}>
+const Home = ({ data = {}, fontsLoaded = '', fullUrl = '' }) => (
+  <Layout
+    title="Hike One - Home"
+    fontsLoaded={fontsLoaded}
+    seo={data.seo}
+    url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
+
       <article className="article">
         <PageHeader
           onClickScrollButton={() => scrollToElement(scrollToTargetClass)}
-          video={Data.header.video}
-          title={Data.header.title}
-          subtitle={Data.header.subtitle}
-          image={Data.header.backgroundImage.url}
-          showGradient={Data.header.displayGradient}>
+          video={data.header.video}
+          title={data.header.title}
+          subtitle={data.header.subtitle}
+          image={data.header.backgroundImage.url}
+          showGradient={data.header.displayGradient}>
           <PageHeaderShapes.variation1Front position="front" />
           <PageHeaderShapes.variation1Back position="back" />
         </PageHeader>
 
-          <div className={`${scrollToTargetClass} page-scrolling-content`}>
-            <ServicesOverviewSmall
-              title={Data.servicesItemTitle}
-              services={Data.serviceItems}
-            />
-          )}
-
+        <div className={`${scrollToTargetClass} page-scrolling-content`}>
           <ServicesOverviewSmall
-            title={Data.servicesItemTitle}
-            services={Data.serviceItems}
+            title={data.servicesItemTitle}
+            services={data.serviceItems}
           />
 
           <TextCenter
             classes="text-center-font-medium text-center-spacing-small"
-            title={Data.caseExtractTitle}
-            text={Data.caseExtractIntro}
+            title={data.caseExtractTitle}
+            text={data.caseExtractIntro}
           />
 
           <CaseExtract
-            color={Data.caseExtract.case.caseThemeColor.hex}
-            companyName={Data.caseExtract.case.companyName}
-            headerImage={Data.caseExtract.image.url}
-            title={Data.caseExtract.title}
-            subtitle={Data.caseExtract.subtitle}
-            slug={Data.caseExtract.case.slug}
+            color={data.caseExtract.case.caseThemeColor.hex}
+            companyName={data.caseExtract.case.companyName}
+            headerImage={data.caseExtract.image.url}
+            title={data.caseExtract.title}
+            subtitle={data.caseExtract.subtitle}
+            slug={data.caseExtract.case.slug}
           />
 
           <TextCenter
             classes="text-center-font-medium text-center-spacing-small"
-            title={Data.eventsTitle}
-            text={Data.eventsIntro}
+            title={data.eventsTitle}
+            text={data.eventsIntro}
           />
 
           <UpdateOverviewSmall>
-            {Data.updateLinks.map((item, index) => (
+            {data.updateLinks.map((item, index) => (
               <UpdateExtractSmall
                 key={index}
                 index={index}
@@ -88,16 +88,16 @@ const Home = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
           </UpdateOverviewSmall>
 
           <Contact
-            title={Data.contact.title}
-            button={Data.contact.button}
-            link={Data.contact.externalLink}>
+            title={data.contact.title}
+            button={data.contact.button}
+            link={data.contact.externalLink}>
             <ContactShapes.variation1Front position="front" />
           </Contact>
 
         </div>
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -105,15 +105,15 @@ const Home = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
 
 Home.getInitialProps = async ({ req, res, asPath }) => {
   const baseUrl = req ? `${req.protocol}://${req.get('Host')}` : ''
+  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
   const fullUrl = `${baseUrl}${asPath}`
   const data = await getData(baseUrl, 'home', res)
-  const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
 
-  return { Data: data, fontsLoaded, fullUrl }
+  return { data, fontsLoaded, fullUrl }
 }
 
 Home.propTypes = {
-  Data: PropTypes.object,
+  data: PropTypes.object,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,
 }

--- a/pages/service.js
+++ b/pages/service.js
@@ -4,7 +4,6 @@ import 'isomorphic-fetch'
 import getData from '../lib/get-data'
 import cookie from '../components/_helpers/cookie'
 import getDateFormat from '../components/_helpers/getDateFormat'
-const Service = ({ Data = {}, services = [], fontsLoaded = '', fullUrl = '' }) => (
 import {
   CaseExtractSmall,
   CompanyOverviewItemSmall,
@@ -22,28 +21,32 @@ import {
   UpdateLinks,
   WorkOverview,
 } from '../components'
+
+const Service = ({ data = {}, services = [], fontsLoaded = '', fullUrl = '' }) => (
   <Layout
-    title={`Hike One - ${Data.title}`}
+    title={`Hike One - ${data.title}`}
     fontsLoaded={fontsLoaded}
-    seo={Data.seo}
+    seo={data.seo}
     url={fullUrl}>
     <main className="main js-main service-page">
+
       <MenuBar color="white" />
+
       <article className="article">
         <PageHeader
           isSmall={true}
-          title={Data.header.title}
-          subtitle={Data.header.subtitle}
-          image={Data.header.backgroundImage.url}
+          title={data.header.title}
+          subtitle={data.header.subtitle}
+          image={data.header.backgroundImage.url}
         />
 
         <div className={`page-scrolling-content-small`}>
-          <TabSelector selectedItem={Data.slug} services={services} />
+          <TabSelector selectedItem={data.slug} services={services} />
 
-          <TextCenter title={Data.introTitle} text={Data.introText} />
+          <TextCenter title={data.introTitle} text={data.introText} />
 
           <CompanyOverviewSmall>
-            {Data.companyReference1.map((service, index) => (
+            {data.companyReference1.map((service, index) => (
               <CompanyOverviewItemSmall
                 companyLogo={service.companyLogo.url}
                 referenceCaseLink=""
@@ -54,7 +57,7 @@ import {
             ))}
           </CompanyOverviewSmall>
 
-          {Data.content.map((component, index) => {
+          {data.content.map((component, index) => {
             switch (component.itemType) {
               case '40_60_text_right':
                 return (
@@ -82,14 +85,14 @@ import {
           })}
 
           <Contact
-            title={Data.contact.title}
-            button={Data.contact.button}
-            link={Data.contact.externalLink}>
+            title={data.contact.title}
+            button={data.contact.button}
+            link={data.contact.externalLink}>
             <ContactShapes.variation1Front position="front" />
           </Contact>
 
-          <WorkOverview header={Data.caseExtractTitle}>
-            {Data.caseExtract.map((item, index) => (
+          <WorkOverview header={data.caseExtractTitle}>
+            {data.caseExtract.map((item, index) => (
               <CaseExtractSmall
                 key={index}
                 title={item.header.title}
@@ -103,7 +106,7 @@ import {
           </WorkOverview>
 
           <UpdateLinks>
-            {Data.updateLinks.map((update, index) => (
+            {data.updateLinks.map((update, index) => (
               <UpdateLink
                 key={index}
                 title={update.title}
@@ -117,7 +120,7 @@ import {
         </div>
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -131,11 +134,11 @@ Service.getInitialProps = async ({ req, res, query, asPath }) => {
   const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
   const [data, services, updates] = await fetchAll([ `services/${query.slug}`, 'services', 'update-extracts' ])
 
-  return { Data: data, services, updates, fontsLoaded, fullUrl }
+  return { data, services, updates, fontsLoaded, fullUrl }
 }
 
 Service.propTypes = {
-  Data: PropTypes.object,
+  data: PropTypes.object,
   services: PropTypes.array,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,

--- a/pages/service.js
+++ b/pages/service.js
@@ -1,28 +1,27 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-
-import Layout from '../components/layout/layout'
-import MenuBar from '../components/menu-bar/menu-bar'
-import Footer from '../components/footer/footer'
-import Contact from '../components/contact/contact'
-import * as ContactShapes from '../components/contact/contact-shapes'
-import CaseExtractSmall from '../components/case-extract-small/case-extract-small'
-import FiftyFifty from '../components/50-50/50-50'
-import PageHeader from '../components/page-header/page-header'
-import TextCenter from '../components/text-center/text-center'
-import WorkOverview from '../components/work-overview/work-overview'
-import TabSelector from '../components/tab-selector/tab-selector'
-import CompanyOverviewSmall from '../components/company-overview-small/company-overview-small'
-import CompanyOverviewItemSmall from '../components/company-overview-item-small/company-overview-item-small'
-import UpdateLinks from '../components/update-links/update-links'
-import UpdateLink from '../components/update-link/update-link'
-
+import getData from '../lib/get-data'
 import cookie from '../components/_helpers/cookie'
 import getDateFormat from '../components/_helpers/getDateFormat'
-import getData from '../lib/get-data'
-
 const Service = ({ Data = {}, services = [], fontsLoaded = '', fullUrl = '' }) => (
+import {
+  CaseExtractSmall,
+  CompanyOverviewItemSmall,
+  CompanyOverviewSmall,
+  Contact,
+  ContactShapes,
+  FiftyFifty,
+  Footer,
+  Layout,
+  MenuBar,
+  PageHeader,
+  TabSelector,
+  TextCenter,
+  UpdateLink,
+  UpdateLinks,
+  WorkOverview,
+} from '../components'
   <Layout
     title={`Hike One - ${Data.title}`}
     fontsLoaded={fontsLoaded}

--- a/pages/team.js
+++ b/pages/team.js
@@ -24,10 +24,10 @@ if (!process.browser) {
 
 const Team = ({
   tab = '',
-  TeamOverviewData = {},
-  TeamMembersData = [],
-  VacanciesOverviewData = {},
-  VacanciesData = [],
+  teamOverviewData = {},
+  teamData = [],
+  vacanciesOverviewData = {},
+  vacanciesData = [],
   fontsLoaded = '',
   fullUrl = '',
   queryParam = '',
@@ -35,7 +35,7 @@ const Team = ({
   <Layout
     title="Hike One - Team"
     fontsLoaded={fontsLoaded}
-    seo={TeamOverviewData.seo}
+    seo={teamOverviewData.seo}
     url={fullUrl}>
     <main className="main js-main">
       <MenuBar color="white" />
@@ -43,34 +43,34 @@ const Team = ({
       <article className="article">
         <PageHeader
           isSmall={true}
-          title={TeamOverviewData.header.title}
-          subtitle={TeamOverviewData.header.subtitle}
-          image={TeamOverviewData.header.backgroundImage.url}
+          title={teamOverviewData.header.title}
+          subtitle={teamOverviewData.header.subtitle}
+          image={teamOverviewData.header.backgroundImage.url}
         />
 
         <div className={`page-scrolling-content-small`}>
           <TeamSelector slug={tab} />
           {tab === 'culture' && (
             <TeamOverview
-              data={TeamOverviewData}
+              data={teamOverviewData}
             />
           )}
           {tab === 'people' && (
             <TeamMembersOverview
               introText={TeamMembersOverview.peopleTabIntro}
-              team={TeamMembersData}
+              team={teamData}
               queryParam={queryParam}
             />
           )}
           <VacancyOverview
-            overview={VacanciesOverviewData}
-            vacancies={VacanciesData}
+            overview={vacanciesOverviewData}
+            vacancies={vacanciesData}
           />
         </div>
 
       </article>
 
-      <Footer form={TeamOverviewData.footer.form} />
+      <Footer form={teamOverviewData.footer.form} />
 
     </main>
   </Layout>
@@ -89,11 +89,11 @@ Team.getInitialProps = async ({ req, res, query, asPath }) => {
     return handleError(res)
   }
 
-  const VacanciesData = await fetch(`https://homerun.co/embed/ahz3le8c0dl4ivfruo0n/widget.html?t=${Date.now()}`)
+  const vacanciesData = await fetch(`https://homerun.co/embed/ahz3le8c0dl4ivfruo0n/widget.html?t=${Date.now()}`)
     .then(response => response.text())
     .then(await scrapeJobs)
 
-  const [TeamOverviewData, TeamMembersData, VacanciesOverviewData] = await fetchAll([
+  const [teamOverviewData, teamData, vacanciesOverviewData] = await fetchAll([
     'team',
     'people',
     'vacancies-overview',
@@ -101,10 +101,10 @@ Team.getInitialProps = async ({ req, res, query, asPath }) => {
 
   return {
     tab,
-    TeamOverviewData,
-    TeamMembersData,
-    VacanciesOverviewData,
-    VacanciesData,
+    teamOverviewData,
+    teamData,
+    vacanciesOverviewData,
+    vacanciesData,
     fontsLoaded,
     fullUrl,
     queryParam,
@@ -113,10 +113,10 @@ Team.getInitialProps = async ({ req, res, query, asPath }) => {
 
 Team.propTypes = {
   tab: PropTypes.string,
-  TeamOverviewData: PropTypes.object,
-  TeamMembersData: PropTypes.array,
-  VacanciesOverviewData: PropTypes.object,
-  VacanciesData: PropTypes.array,
+  teamOverviewData: PropTypes.object,
+  teamData: PropTypes.array,
+  vacanciesOverviewData: PropTypes.object,
+  vacanciesData: PropTypes.array,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,
   queryParam: PropTypes.string,

--- a/pages/team.js
+++ b/pages/team.js
@@ -1,17 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-
-import Layout from '../components/layout/layout'
-import MenuBar from '../components/menu-bar/menu-bar'
-import Footer from '../components/footer/footer'
-import PageHeader from '../components/page-header/page-header'
-import TeamSelector from '../components/team-selector/team-selector'
-import TeamOverview from '../components/team-overview/team-overview'
-import TeamMembersOverview from '../components/team-members-overview/team-members-overview'
-import VacancyOverview from '../components/vacancy-overview/vacancy-overview'
-import cookie from '../components/_helpers/cookie'
 import getData, { handleError } from '../lib/get-data'
+import cookie from '../components/_helpers/cookie'
+import {
+  Footer,
+  Layout,
+  MenuBar,
+  PageHeader,
+  TeamMembersOverview,
+  TeamOverview,
+  TeamSelector,
+  VacancyOverview,
+} from '../components'
 
 let scrapeJobs
 

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -11,23 +11,27 @@ import {
   TextCenterShapes,
 } from '../components'
 
-const ThankYou = ({ page = {}, fontsLoaded = '', fullUrl = '' }) => (
-  <Layout title="Hike One - Thank you" fontsLoaded={fontsLoaded} url={fullUrl}>
+const ThankYou = ({ data = {}, fontsLoaded = '', fullUrl = '' }) => (
+  <Layout
+    title="Hike One - Thank you"
+    fontsLoaded={fontsLoaded}
+    url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="black" />
 
       <article className="article article-thank-you">
-        <TextCenter title={page.title} text={page.content}>
+        <TextCenter title={data.title} text={data.content}>
           <TextCenterShapes.variation3Back position="back" />
           <TextCenterShapes.variation4Front position="front" />
         </TextCenter>
 
-        <ButtonPrimaryLink href={page.callToActionUrl} classes="btn btn-large btn-centered">
-          {page.callToActionLabel}
+        <ButtonPrimaryLink href={data.callToActionUrl} classes="btn btn-large btn-centered">
+          {data.callToActionLabel}
         </ButtonPrimaryLink>
       </article>
 
-      <Footer form={page.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -37,13 +41,13 @@ ThankYou.getInitialProps = async ({ req, res, asPath }) => {
   const baseUrl = req ? `${req.protocol}://${req.get('Host')}` : ''
   const fullUrl = `${baseUrl}${asPath}`
   const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
-  const page = await getData(baseUrl, 'thank-you', res)
+  const data = await getData(baseUrl, 'thank-you', res)
 
-  return { page, fontsLoaded, fullUrl }
+  return { data, fontsLoaded, fullUrl }
 }
 
 ThankYou.propTypes = {
-  page: PropTypes.object,
+  data: PropTypes.object,
   fontsLoaded: PropTypes.bool,
   fullUrl: PropTypes.string,
 }

--- a/pages/thank-you.js
+++ b/pages/thank-you.js
@@ -1,17 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import getData from '../lib/get-data'
 import cookie from '../components/_helpers/cookie'
-
 import {
   ButtonPrimaryLink,
   Footer,
-  MenuBar,
   Layout,
+  MenuBar,
   TextCenter,
   TextCenterShapes,
 } from '../components'
-
-import getData from '../lib/get-data'
 
 const ThankYou = ({ page = {}, fontsLoaded = '', fullUrl = '' }) => (
   <Layout title="Hike One - Thank you" fontsLoaded={fontsLoaded} url={fullUrl}>

--- a/pages/topic.js
+++ b/pages/topic.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-
 import getData from '../lib/get-data'
 import cookie from '../components/_helpers/cookie'
-
 import {
   BodyQuote,
   CallToAction,

--- a/pages/topic.js
+++ b/pages/topic.js
@@ -26,25 +26,26 @@ import {
   WorkOverview,
 } from '../components'
 
-const Topic = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
+const Topic = ({ data = {}, fontsLoaded = '', fullUrl = '' }) => (
   <Layout
-    title={`Hike One - ${Data.title}`}
+    title={`Hike One - ${data.title}`}
     fontsLoaded={fontsLoaded}
-    seo={Data.seo}
+    seo={data.seo}
     url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
 
       <article className="article">
         <FullWidthHeader
-          headerImage={Data.headerImage.url}
-          headerImageLarger={Data.headerImageLarger}
-          color={Data.color.hex}
-          title={Data.title}
+          headerImage={data.headerImage.url}
+          headerImageLarger={data.headerImageLarger}
+          color={data.color.hex}
+          title={data.title}
           titleOnly={true}
         />
 
-        {Data.content.map((component, index) => {
+        {data.content.map((component, index) => {
           switch (component.itemType) {
             case 'rich_body_text':
               return (
@@ -156,25 +157,25 @@ const Topic = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
 
         <SocialShare
           facebookLink={`https://www.facebook.com/sharer/sharer.php?u=${fullUrl}`}
-          linkedinLink={`https://www.linkedin.com/shareArticle?mini=true&url=${fullUrl}&title=${Data.title}&summary=${Data.seo.description}&source=Hike&20One`}
-          twitterLink={`https://twitter.com/intent/tweet?text=${Data.title}&url=${fullUrl}`}
+          linkedinLink={`https://www.linkedin.com/shareArticle?mini=true&url=${fullUrl}&title=${data.title}&summary=${data.seo.description}&source=Hike&20One`}
+          twitterLink={`https://twitter.com/intent/tweet?text=${data.title}&url=${fullUrl}`}
         />
 
-        {Data.contact && (
+        {data.contact && (
           <Contact
-            title={Data.contact.title}
-            button={Data.contact.button}
-            link={Data.contact.externalLink}
+            title={data.contact.title}
+            button={data.contact.button}
+            link={data.contact.externalLink}
             target="_blank" rel="noopener noreferrer">
             <ContactShapes.variation1Front position="front" />
           </Contact>
         )}
 
-        <TextCenter title={Data.caseLinksTitle} />
+        <TextCenter title={data.caseLinksTitle} />
 
-        {Data.caseLinks.length > 0 && (
+        {data.caseLinks.length > 0 && (
           <WorkOverview>
-            {Data.caseLinks.map((item, index) => (
+            {data.caseLinks.map((item, index) => (
               <CaseExtractSmall
                 key={index}
                 title={item.header.title}
@@ -188,12 +189,12 @@ const Topic = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
           </WorkOverview>
         )}
 
-        {Data.updateLinks.length > 0 && (
+        {data.updateLinks.length > 0 && (
           <React.Fragment>
-            <TextCenter title={Data.updateLinksTitle} />
+            <TextCenter title={data.updateLinksTitle} />
 
             <UpdateOverviewSmall>
-              {Data.updateLinks.map((item, index) => (
+              {data.updateLinks.map((item, index) => (
                 <UpdateExtractSmall
                   key={index}
                   index={index}
@@ -212,7 +213,7 @@ const Topic = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
         )}
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -224,11 +225,11 @@ Topic.getInitialProps = async ({ req, res, query, asPath }) => {
   const data = await getData(baseUrl, `topics/${query.slug}`, res)
   const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
 
-  return { Data: data, fontsLoaded, fullUrl }
+  return { data, fontsLoaded, fullUrl }
 }
 
 Topic.propTypes = {
-  Data: PropTypes.object,
+  data: PropTypes.object,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,
 }

--- a/pages/update.js
+++ b/pages/update.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-
 import getData from '../lib/get-data'
 import cookie from '../components/_helpers/cookie'
-
 import {
   Author,
   BodyQuote,

--- a/pages/update.js
+++ b/pages/update.js
@@ -24,24 +24,25 @@ import {
   UpdateOverviewSmall,
 } from '../components'
 
-const Update = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
+const Update = ({ data = {}, fontsLoaded = '', fullUrl = '' }) => (
   <Layout
-    title={`Hike One - ${Data.title}`}
+    title={`Hike One - ${data.title}`}
     fontsLoaded={fontsLoaded}
-    seo={Data.seo}
+    seo={data.seo}
     url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
 
       <article className="article">
         <FullWidthHeader
-          headerImage={Data.headerImage.url}
-          color={Data.color.hex}
-          title={Data.title}
-          authorName={Data.authors.map(author => author.name).join(', ')}
-          updatedDate={Data.date}
+          headerImage={data.headerImage.url}
+          color={data.color.hex}
+          title={data.title}
+          authorName={data.authors.map(author => author.name).join(', ')}
+          updatedDate={data.date}
         />
-        {Data.content.map((component, index) => {
+        {data.content.map((component, index) => {
           switch (component.itemType) {
             case '50_50':
               return (
@@ -160,12 +161,12 @@ const Update = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
 
         <SocialShare
           facebookLink={`https://www.facebook.com/sharer/sharer.php?u=${fullUrl}`}
-          linkedinLink={`https://www.linkedin.com/shareArticle?mini=true&url=${fullUrl}&title=${Data.title}&summary=${Data.seo.description}&source=Hike&20One`}
-          twitterLink={`https://twitter.com/intent/tweet?text=${Data.title}&url=${fullUrl}`}
+          linkedinLink={`https://www.linkedin.com/shareArticle?mini=true&url=${fullUrl}&title=${data.title}&summary=${data.seo.description}&source=Hike&20One`}
+          twitterLink={`https://twitter.com/intent/tweet?text=${data.title}&url=${fullUrl}`}
         />
 
         <div className="authors">
-          {Data.authors.map((author, index) => {
+          {data.authors.map((author, index) => {
             return (
               <Author
                 key={index}
@@ -178,11 +179,11 @@ const Update = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
           })}
         </div>
 
-        {Data.contact && (
+        {data.contact && (
           <Contact
-            title={Data.contact.title}
-            button={Data.contact.button}
-            link={Data.contact.externalLink}
+            title={data.contact.title}
+            button={data.contact.button}
+            link={data.contact.externalLink}
             target="_blank" rel="noopener noreferrer">
             <ContactShapes.variation1Front position="front" />
           </Contact>
@@ -190,11 +191,11 @@ const Update = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
 
         <TextCenter
           classes="text-center-font-medium text-center-spacing-small"
-          title={Data.updateLinksTitle}
+          title={data.updateLinksTitle}
         />
 
         <UpdateOverviewSmall>
-          {Data.updateLinks.map((item, index) => (
+          {data.updateLinks.map((item, index) => (
             <UpdateExtractSmall
               key={index}
               index={index}
@@ -211,7 +212,7 @@ const Update = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
         </UpdateOverviewSmall>
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -223,11 +224,11 @@ Update.getInitialProps = async ({ req, res, query, asPath }) => {
   const data = await getData(baseUrl, `updates/${query.slug}`, res)
   const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
 
-  return { Data: data, fontsLoaded, fullUrl }
+  return { data, fontsLoaded, fullUrl }
 }
 
 Update.propTypes = {
-  Data: PropTypes.object,
+  data: PropTypes.object,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,
 }

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -1,13 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-import Layout from '../components/layout/layout'
-import MenuBar from '../components/menu-bar/menu-bar'
-import Footer from '../components/footer/footer'
-import PageHeader from '../components/page-header/page-header'
-import UpdateOverview from '../components/update-overview/update-overview'
-import cookie from '../components/_helpers/cookie'
 import getData from '../lib/get-data'
+import cookie from '../components/_helpers/cookie'
+import {
+  Footer,
+  Layout,
+  MenuBar,
+  PageHeader,
+  UpdateOverview,
+} from '../components'
 
 const Updates = ({ Data = {}, updatesData = [], fontsLoaded = '', fullUrl = '' }) => (
   <Layout title="Hike One - Updates" fontsLoaded={fontsLoaded} seo={Data.seo} url={fullUrl}>

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -11,29 +11,34 @@ import {
   UpdateOverview,
 } from '../components'
 
-const Updates = ({ Data = {}, updatesData = [], fontsLoaded = '', fullUrl = '' }) => (
-  <Layout title="Hike One - Updates" fontsLoaded={fontsLoaded} seo={Data.seo} url={fullUrl}>
+const Updates = ({ data = {}, updates = [], fontsLoaded = '', fullUrl = '' }) => (
+  <Layout
+    title="Hike One - Updates"
+    fontsLoaded={fontsLoaded}
+    seo={data.seo}
+    url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
 
       <article className="article">
         <PageHeader
           isSmall={true}
-          title={Data.header.title}
-          subtitle={Data.header.subtitle}
-          image={Data.header.backgroundImage.url}
+          title={data.header.title}
+          subtitle={data.header.subtitle}
+          image={data.header.backgroundImage.url}
         />
 
         <div className={`page-scrolling-content-small`}>
           <UpdateOverview
-            data={Data}
-            updatesData={updatesData}
+            data={data}
+            updatesData={updates}
           />
         </div>
 
       </article>
 
-      <Footer form={Data.footer.form} />
+      <Footer form={data.footer.form} />
 
     </main>
   </Layout>
@@ -44,18 +49,19 @@ Updates.getInitialProps = async ({ req, res, asPath }) => {
   const fullUrl = `${baseUrl}${asPath}`
   const fetchJson = model => getData(baseUrl, model, res)
   const fetchAll = models => Promise.all(models.map(fetchJson))
-  const [Data, updatesData] = await fetchAll(['update-overview', 'update-extracts'])
+  const [data, updates] = await fetchAll(['update-overview', 'update-extracts'])
   const fontsLoaded = req ? req.cookies['fonts-loaded'] : cookie('fonts-loaded')
-  updatesData.sort((a, b) => {
+
+  updates.sort((a, b) => {
     return new Date(b.date).getTime() - new Date(a.date).getTime()
   })
 
-  return { Data, updatesData, fontsLoaded, fullUrl }
+  return { data, updates, fontsLoaded, fullUrl }
 }
 
 Updates.propTypes = {
-  Data: PropTypes.object,
-  updatesData: PropTypes.array,
+  data: PropTypes.object,
+  updates: PropTypes.array,
   fontsLoaded: PropTypes.string,
   fullUrl: PropTypes.string,
 }

--- a/pages/work.js
+++ b/pages/work.js
@@ -1,17 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import 'isomorphic-fetch'
-import Layout from '../components/layout/layout'
-import MenuBar from '../components/menu-bar/menu-bar'
-import PageHeader from '../components/page-header/page-header'
-import CaseExtractSmall from '../components/case-extract-small/case-extract-small'
-import Contact from '../components/contact/contact'
-import * as ContactShapes from '../components/contact/contact-shapes'
-import Footer from '../components/footer/footer'
-import WorkOverview from '../components/work-overview/work-overview'
-import LogoCarousel from '../components/logo-carousel/logo-carousel'
-import cookie from '../components/_helpers/cookie'
 import getData from '../lib/get-data'
+import cookie from '../components/_helpers/cookie'
+import {
+  CaseExtractSmall,
+  Contact,
+  ContactShapes,
+  Footer,
+  Layout,
+  LogoCarousel,
+  MenuBar,
+  PageHeader,
+  WorkOverview,
+} from '../components'
 
 const Work = ({ cases = [], data = {}, fontsLoaded = '', fullUrl = '' }) => (
   <Layout title="Hike One - Case" fontsLoaded={fontsLoaded} seo={data.seo} url={fullUrl}>

--- a/pages/work.js
+++ b/pages/work.js
@@ -16,9 +16,15 @@ import {
 } from '../components'
 
 const Work = ({ cases = [], data = {}, fontsLoaded = '', fullUrl = '' }) => (
-  <Layout title="Hike One - Case" fontsLoaded={fontsLoaded} seo={data.seo} url={fullUrl}>
+  <Layout
+    title="Hike One - Case"
+    fontsLoaded={fontsLoaded}
+    seo={data.seo}
+    url={fullUrl}>
     <main className="main js-main">
+
       <MenuBar color="white" />
+
       <article className="article work">
         <PageHeader
           isSmall={true}
@@ -51,12 +57,14 @@ const Work = ({ cases = [], data = {}, fontsLoaded = '', fullUrl = '' }) => (
               }
             })}
           </WorkOverview>
+
           <Contact
             title={data.contact.title}
             button={data.contact.button}
             link={data.contact.externalLink}>
             <ContactShapes.variation1Front position="front" />
           </Contact>
+
         </div>
       </article>
 


### PR DESCRIPTION
This pull-request includes:
- Use same way of importing components on all pages (e.g. `import { ...list of component names... } from '../components'` )
- While streamlining these imports I added some missing components to `components/index.js`
- Prop names are now lowercase (e.g. `Data` => `data`)