### PR TITLE
Feature/343 refactor newroles roles and remove old roles from project

### DIFF
--- a/components/author/author.js
+++ b/components/author/author.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import setImageParams from '../_helpers/setImageParameters'
 
-const Author = ({ name = '', role = '', photoUrl = '', summary = '' }) => {
+const Author = ({ name = '', roles = '', photoUrl = '', summary = '' }) => {
   const imageParameters = { fit: 'crop', fm: 'pjpg', q: 85 }
   return (
     <div className="author">
@@ -12,7 +12,7 @@ const Author = ({ name = '', role = '', photoUrl = '', summary = '' }) => {
       />
       <div className="author-text">
         <p className="author-name">{name}</p>
-        <p className="author-role">{role}</p>
+        <p className="author-roles">{roles.map((role) => role.title).join(', ')}</p>
         <p className="author-summary">{summary}</p>
       </div>
     </div>
@@ -21,7 +21,7 @@ const Author = ({ name = '', role = '', photoUrl = '', summary = '' }) => {
 
 Author.propTypes = {
   name: PropTypes.string,
-  role: PropTypes.string,
+  roles: PropTypes.array,
   photoUrl: PropTypes.string,
   summary: PropTypes.string,
 }

--- a/components/author/author.less
+++ b/components/author/author.less
@@ -59,7 +59,7 @@
   }
 }
 
-.author-role {
+.author-roles {
   margin-top: 0;
   margin-bottom: @spacing-default;
   color: @dark-gray;

--- a/components/team-member/team-member.js
+++ b/components/team-member/team-member.js
@@ -8,7 +8,7 @@ const TeamMember = ({ data = {} }) => (
       <h3 className="team-member-name">{data.name}</h3>
       <div className="team-member-roles">
         {data.newRoles.map((role, index) => (
-          <p className="team-member-role" key={index}>{role.title}</p>
+          <span className="team-member-role" key={index}>{role.title}</span>
         ))}
       </div>
     </div>

--- a/components/team-member/team-member.less
+++ b/components/team-member/team-member.less
@@ -95,6 +95,7 @@
 }
 
 .team-member-role {
+  display: block;
   margin: 0;
   padding: 0;
   font-size: @subtitle-small-s;

--- a/pages/update.js
+++ b/pages/update.js
@@ -172,7 +172,7 @@ const Update = ({ Data = {}, fontsLoaded = '', fullUrl = '' }) => (
               <Author
                 key={index}
                 name={author.name}
-                role={author.role}
+                roles={author.newRoles}
                 photoUrl={author.photo.url}
                 summary={author.summary}
               />


### PR DESCRIPTION
This pull-request includes:
- Use `newRoles` field for roles.

When merged, I will remove the old `roles` field in Dato and rename `newRoles` to `roles`.