### PR TITLE
fix(menu-bar) removed heading from logo link

### DIFF
--- a/components/menu-bar/menu-bar.js
+++ b/components/menu-bar/menu-bar.js
@@ -181,7 +181,7 @@ class MenuBar extends Component {
           <Link href="/">
             <a className="header-logo" onContextMenu={this.toggleContextMenu}>
               <Logo color={`${color ? color : 'black'}`} />
-              <h1 className="a11y-sr-only">Hike one</h1>
+              <span className="a11y-sr-only">Hike one</span>
             </a>
           </Link>
           <ContextMenu isOpen={this.state.contextMenuIsOpen} />


### PR DESCRIPTION
This pull-request includes:
- Replaced `<h1>` with `<span>`