### PR TITLE
Feat/social share

### DIFF
--- a/components/buttons/button-primary/button-primary-link.js
+++ b/components/buttons/button-primary/button-primary-link.js
@@ -10,7 +10,7 @@ const PrimaryButtonLink = ({
 	icon = '',
 	target = '_self',
 }) => (
-	<Link href={href} as={`${hrefAs ? hrefAs : href}`}>
+	<Link href={href} as={`${hrefAs ? hrefAs : href}`} prefetch={target ? false : null}>
 		<a target={target} className={`btn-primary ${classes} ${icon ? 'btn-icon' : ''}`}>
 			{children}
 			{icon && (

--- a/components/buttons/button-secondary/button-secondary-link.js
+++ b/components/buttons/button-secondary/button-secondary-link.js
@@ -10,7 +10,7 @@ const ButtonSecondaryLink = ({
 	icon = '',
 	target = '_self',
 }) => (
-	<Link href={href} as={`${hrefAs ? hrefAs : href}`}>
+	<Link href={href} as={`${hrefAs ? hrefAs : href}`} prefetch={target ? false : null}>
 		<a target={target} className={`btn-secondary ${classes} ${icon ? 'btn-icon' : ''}`}>
 			{children}
 			{icon && (

--- a/components/social-media/social-media.js
+++ b/components/social-media/social-media.js
@@ -1,8 +1,8 @@
 import Facebook from '../icons/facebook-circle';
-import Twitter from '../icons/twitter-circle';
+import Instagram from '../icons/instagram-circle';
 import LinkedIn from '../icons/linkedin-circle';
 import Medium from '../icons/medium-circle';
-import Instagram from '../icons/instagram-circle';
+import Twitter from '../icons/twitter-circle';
 
 const SocialMedia = () => (
 	<div className="menu-social">

--- a/components/social-share/social-share.js
+++ b/components/social-share/social-share.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import Facebook from '../icons/facebook-circle';
 import LinkedIn from '../icons/linkedin-circle';

--- a/components/social-share/social-share.js
+++ b/components/social-share/social-share.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Facebook from '../icons/facebook-circle';
+import LinkedIn from '../icons/linkedin-circle';
+import Twitter from '../icons/twitter-circle';
+
+const facebookBase = 'https://www.facebook.com/sharer.php';
+const linkedinBase = 'https://www.linkedin.com/shareArticle';
+const twitterBase = 'https://twitter.com/intent/tweet';
+
+const SocialShare = ({ description = '', title = '', url = '' }) => (
+	<div className="social-share">
+		<a
+			href={`${facebookBase}?u=${url}`}
+			className="social-share-item"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<Facebook color="facebook-blue" />
+		</a>
+		<a
+			href={`${twitterBase}?text=${title}&url=${url}`}
+			className="social-share-item"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<Twitter color="twitter-blue" />
+		</a>
+		<a
+			href={`${linkedinBase}?mini=true&url=${url}&title=${title}&summary=${description}&source=Hike&20One`}
+			className="social-share-item"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<LinkedIn color="linkedin-blue" />
+		</a>
+	</div>
+);
+
+SocialShare.propTypes = {
+	description: PropTypes.string,
+	title: PropTypes.string,
+	url: PropTypes.string,
+};
+
+export default SocialShare;

--- a/components/social-share/social-share.less
+++ b/components/social-share/social-share.less
@@ -6,25 +6,37 @@
 	justify-content: center;
 	width: 100%;
 	margin-bottom: @spacing-default*4;
+	border-top-left-radius: 4px;
+	border-bottom-left-radius: 4px;
 
 	@media @screen-768 {
 		position: fixed;
-		top: 240px;
+		top: 250px;
 		right: 0;
+		left: auto;
 		flex-direction: column;
 		align-items: center;
-		width: 56px;
+		width: auto;
 		height: 150px;
 		margin-bottom: 0;
 		padding: @spacing-default;
 		background-color: @white;
-		box-shadow: 0 10px 100px 0 fade(@black, 15%);
+		box-shadow: 0 10px 50px 0 fade(@black, 20%);
+	}
+
+	svg {
+		display: block;
+		width: 56px;
+		height: 56px;
+
+		@media @screen-768 {
+			width: 42px;
+			height: 42px;
+		}
 	}
 }
 
 .social-share-item {
-	margin-right: @spacing-default;
-
 	&:last-child {
 		margin-right: 0;
 	}
@@ -47,21 +59,16 @@
 		}
 	}
 
-	svg {
-		width: 56px;
-		height: 56px;
-	}
-
 	svg path {
 		transition: fill @animation-speed;
 	}
+}
+
+.social-share-item + .social-share-item {
+	margin-left: @spacing-default;
 
 	@media @screen-768 {
-		margin-right: 0;
-
-		svg {
-			width: 42px;
-			height: 42px;
-		}
+		margin-top: @spacing-default*0.5;
+		margin-left: 0;
 	}
 }

--- a/components/social-share/social-share.less
+++ b/components/social-share/social-share.less
@@ -1,0 +1,67 @@
+@import (reference) '../../styles/variables';
+
+.social-share {
+  display: flex;
+  z-index: @layer-raised;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: @spacing-default*4;
+
+  @media @screen-768 {
+    position: fixed;
+    top: 240px;
+    right: 0;
+    flex-direction: column;
+    align-items: center;
+    width: 56px;
+    height: 150px;
+    margin-bottom: 0;
+    padding: @spacing-default;
+    background-color: @white;
+    box-shadow: 0 10px 100px 0 fade(@black, 15%);
+  }
+}
+
+.social-share-item {
+  margin-right: @spacing-default;
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  &:hover {
+    svg path {
+      transition: fill @animation-speed-fast;
+    }
+
+    .facebook-blue path {
+      fill: darken(@facebook-blue, 10%);
+    }
+
+    .twitter-blue path {
+      fill: darken(@twitter-blue, 10%);
+    }
+
+    .linkedin-blue path {
+      fill: darken(@linkedin-blue, 10%);
+    }
+  }
+
+  svg {
+    width: 56px;
+    height: 56px;
+  }
+
+  svg path {
+    transition: fill @animation-speed;
+  }
+
+  @media @screen-768 {
+    margin-right: 0;
+
+    svg {
+      width: 42px;
+      height: 42px;
+    }
+  }
+}

--- a/components/social-share/social-share.less
+++ b/components/social-share/social-share.less
@@ -1,67 +1,67 @@
 @import (reference) '../../styles/variables';
 
 .social-share {
-  display: flex;
-  z-index: @layer-raised;
-  justify-content: center;
-  width: 100%;
-  margin-bottom: @spacing-default*4;
+	display: flex;
+	z-index: @layer-raised;
+	justify-content: center;
+	width: 100%;
+	margin-bottom: @spacing-default*4;
 
-  @media @screen-768 {
-    position: fixed;
-    top: 240px;
-    right: 0;
-    flex-direction: column;
-    align-items: center;
-    width: 56px;
-    height: 150px;
-    margin-bottom: 0;
-    padding: @spacing-default;
-    background-color: @white;
-    box-shadow: 0 10px 100px 0 fade(@black, 15%);
-  }
+	@media @screen-768 {
+		position: fixed;
+		top: 240px;
+		right: 0;
+		flex-direction: column;
+		align-items: center;
+		width: 56px;
+		height: 150px;
+		margin-bottom: 0;
+		padding: @spacing-default;
+		background-color: @white;
+		box-shadow: 0 10px 100px 0 fade(@black, 15%);
+	}
 }
 
 .social-share-item {
-  margin-right: @spacing-default;
+	margin-right: @spacing-default;
 
-  &:last-child {
-    margin-right: 0;
-  }
+	&:last-child {
+		margin-right: 0;
+	}
 
-  &:hover {
-    svg path {
-      transition: fill @animation-speed-fast;
-    }
+	&:hover {
+		svg path {
+			transition: fill @animation-speed-fast;
+		}
 
-    .facebook-blue path {
-      fill: darken(@facebook-blue, 10%);
-    }
+		.facebook-blue path {
+			fill: darken(@facebook-blue, 10%);
+		}
 
-    .twitter-blue path {
-      fill: darken(@twitter-blue, 10%);
-    }
+		.twitter-blue path {
+			fill: darken(@twitter-blue, 10%);
+		}
 
-    .linkedin-blue path {
-      fill: darken(@linkedin-blue, 10%);
-    }
-  }
+		.linkedin-blue path {
+			fill: darken(@linkedin-blue, 10%);
+		}
+	}
 
-  svg {
-    width: 56px;
-    height: 56px;
-  }
+	svg {
+		width: 56px;
+		height: 56px;
+	}
 
-  svg path {
-    transition: fill @animation-speed;
-  }
+	svg path {
+		transition: fill @animation-speed;
+	}
 
-  @media @screen-768 {
-    margin-right: 0;
+	@media @screen-768 {
+		margin-right: 0;
 
-    svg {
-      width: 42px;
-      height: 42px;
-    }
-  }
+		svg {
+			width: 42px;
+			height: 42px;
+		}
+	}
 }

--- a/pages/topic/[slug].js
+++ b/pages/topic/[slug].js
@@ -3,16 +3,17 @@ import '../../styles/index.less';
 import fetchContent from '../../lib/fetch-content';
 import withCacheControl from '../../lib/with-cache-control';
 
-import Head from '../../components/head/head';
 import BodyQuote from '../../components/body-quote/body-quote';
 import CallToAction from '../../components/call-to-action/call-to-action';
+import CaseExtractSmall from '../../components/case-extract-small/case-extract-small';
 import Contact from '../../components/contact/contact';
-import ContactShapes from '../../components/contact/contact-shapes';
 import ContactForm from '../../components/contact-form/contact-form';
+import ContactShapes from '../../components/contact/contact-shapes';
 import FiftyFifty from '../../components/50-50/50-50';
 import Footer from '../../components/footer/footer';
 import FullWidthHeader from '../../components/full-width-header/full-width-header';
 import FullWidthImageSmall from '../../components/full-width-image-small/full-width-image-small';
+import Head from '../../components/head/head';
 import InlineMedia from '../../components/inline-media/inline-media';
 import LogoCarousel from '../../components/logo-carousel/logo-carousel';
 import MailchimpForm from '../../components/mailchimp/mailchimp-form';
@@ -23,7 +24,6 @@ import TextCenter from '../../components/text-center/text-center';
 import UpdateExtractSmall from '../../components/update-extract-small/update-extract-small';
 import UpdateOverviewSmall from '../../components/update-overview-small/update-overview-small';
 import WorkOverview from '../../components/work-overview/work-overview';
-import CaseExtractSmall from '../../components/case-extract-small/case-extract-small';
 
 const Page = ({ topic, footer, fullUrl }) => (
 	<>

--- a/pages/topic/[slug].js
+++ b/pages/topic/[slug].js
@@ -18,13 +18,14 @@ import LogoCarousel from '../../components/logo-carousel/logo-carousel';
 import MailchimpForm from '../../components/mailchimp/mailchimp-form';
 import MenuBar from '../../components/menu-bar/menu-bar';
 import RichBodyText from '../../components/rich-body-text/rich-body-text';
+import SocialShare from '../../components/social-share/social-share';
 import TextCenter from '../../components/text-center/text-center';
 import UpdateExtractSmall from '../../components/update-extract-small/update-extract-small';
 import UpdateOverviewSmall from '../../components/update-overview-small/update-overview-small';
 import WorkOverview from '../../components/work-overview/work-overview';
 import CaseExtractSmall from '../../components/case-extract-small/case-extract-small';
 
-const Page = ({ topic, footer }) => (
+const Page = ({ topic, footer, fullUrl }) => (
 	<>
 		<Head
 			title={topic.seo.title}
@@ -162,6 +163,8 @@ const Page = ({ topic, footer }) => (
 				})}
 			</main>
 
+			<SocialShare url={fullUrl} title={data.title} description={data.seo.description} />
+
 			{topic.contact && (
 				<Contact
 					title={topic.contact.title}
@@ -223,6 +226,7 @@ const Page = ({ topic, footer }) => (
 );
 
 Page.getInitialProps = withCacheControl(({ req, query, asPath }) => {
+	const fullUrl = `${req.headers.host}${asPath}`;
 	const graphqlQuery = `{
 		topic(filter: { slug: { eq: "${query.slug}" } }) {
 			title
@@ -415,7 +419,7 @@ Page.getInitialProps = withCacheControl(({ req, query, asPath }) => {
 		}
 	}`;
 
-	return fetchContent({ graphqlQuery, req });
+	return fetchContent({ graphqlQuery, req }).then(res => ({ ...res, fullUrl }));
 });
 
 export default Page;

--- a/pages/update/[slug].js
+++ b/pages/update/[slug].js
@@ -17,12 +17,13 @@ import Contact from '../../components/contact/contact';
 import ContactForm from '../../components/contact-form/contact-form';
 import ContactShapes from '../../components/contact/contact-shapes';
 import Author from '../../components/author/author';
+import SocialShare from '../../components/social-share/social-share';
 import TextCenter from '../../components/text-center/text-center';
 import UpdateOverviewSmall from '../../components/update-overview-small/update-overview-small';
 import UpdateExtractSmall from '../../components/update-extract-small/update-extract-small';
 import Footer from '../../components/footer/footer';
 
-const Page = ({ update, footer }) => (
+const Page = ({ update, footer, fullUrl }) => (
 	<>
 		<Head
 			title={update.seo.title}
@@ -165,6 +166,8 @@ const Page = ({ update, footer }) => (
 				})}
 			</main>
 
+			<SocialShare url={fullUrl} title={update.title} description={update.seo.description} />
+
 			<div className="authors">
 				{update.authors.map((author, index) => {
 					return (
@@ -221,6 +224,7 @@ const Page = ({ update, footer }) => (
 );
 
 Page.getInitialProps = withCacheControl(({ req, query, asPath }) => {
+	const fullUrl = `${req.headers.host}${asPath}`;
 	const graphqlQuery = `{
 		update(filter: { slug: { eq: "${query.slug}" } }) {
 			title
@@ -409,7 +413,7 @@ Page.getInitialProps = withCacheControl(({ req, query, asPath }) => {
 		}
 	}`;
 
-	return fetchContent({ graphqlQuery, req });
+	return fetchContent({ graphqlQuery, req }).then(res => ({ ...res, fullUrl }));
 });
 
 export default Page;

--- a/pages/update/[slug].js
+++ b/pages/update/[slug].js
@@ -3,25 +3,25 @@ import '../../styles/index.less';
 import fetchContent from '../../lib/fetch-content';
 import withCacheControl from '../../lib/with-cache-control';
 
-import Head from '../../components/head/head';
-import MenuBar from '../../components/menu-bar/menu-bar';
-import FullWidthHeader from '../../components/full-width-header/full-width-header';
-import FiftyFifty from '../../components/50-50/50-50';
+import Author from '../../components/author/author';
 import BodyQuote from '../../components/body-quote/body-quote';
 import CallToAction from '../../components/call-to-action/call-to-action';
-import FullWidthImageSmall from '../../components/full-width-image-small/full-width-image-small';
-import InlineMedia from '../../components/inline-media/inline-media';
-import RichBodyText from '../../components/rich-body-text/rich-body-text';
-import MailchimpForm from '../../components/mailchimp/mailchimp-form';
 import Contact from '../../components/contact/contact';
 import ContactForm from '../../components/contact-form/contact-form';
 import ContactShapes from '../../components/contact/contact-shapes';
-import Author from '../../components/author/author';
+import FiftyFifty from '../../components/50-50/50-50';
+import Footer from '../../components/footer/footer';
+import FullWidthHeader from '../../components/full-width-header/full-width-header';
+import FullWidthImageSmall from '../../components/full-width-image-small/full-width-image-small';
+import Head from '../../components/head/head';
+import InlineMedia from '../../components/inline-media/inline-media';
+import MailchimpForm from '../../components/mailchimp/mailchimp-form';
+import MenuBar from '../../components/menu-bar/menu-bar';
+import RichBodyText from '../../components/rich-body-text/rich-body-text';
 import SocialShare from '../../components/social-share/social-share';
 import TextCenter from '../../components/text-center/text-center';
-import UpdateOverviewSmall from '../../components/update-overview-small/update-overview-small';
 import UpdateExtractSmall from '../../components/update-extract-small/update-extract-small';
-import Footer from '../../components/footer/footer';
+import UpdateOverviewSmall from '../../components/update-overview-small/update-overview-small';
 
 const Page = ({ update, footer, fullUrl }) => (
 	<>

--- a/styles/index.less
+++ b/styles/index.less
@@ -67,6 +67,7 @@
 @import (once) '../components/services-cards/services-cards';
 @import (once) '../components/shapes/shapes';
 @import (once) '../components/social-media/social-media';
+@import (once) '../components/social-share/social-share';
 @import (once) '../components/statistics-block/statistics-block';
 @import (once) '../components/tab-selector/tab-selector';
 @import (once) '../components/team-image/team-image';


### PR DESCRIPTION
This pull-request includes:
- New `SocialShare` component.
- Put `SocialShare` on `/update` and `/topic` pages. Just like on the old website.
- Checked all share options. As long as you don't share your `localhost:3000` local url it works fine.

Also fixed a warning regarding prefetching certain urls (see `button-primary-link.js` and `button-secondary-link.js`)

Note: If an adblocker is active, it might not show up.